### PR TITLE
added issue_template.md to get useful bug reports

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,30 @@
+**Please, do not create duplicate issues**
+
+
+### Actual behaviour
+
+Tell us what happens
+
+
+### Expected behaviour
+
+Tell us what should actually happen
+
+
+### Steps to reproduce
+
+Please supply step-by-step instructions so that anyone with the same environment can reproduce the issue. Whenever you offer a description, imagine
+yourself in the shoes of someone who has never encountered this problem before and would like to know exactly how to observe it under a given set of conditions.
+Here is an example:
+
+1. Open the PonySFM Workshop.exe
+2. Click on button X, then on the menu that appears, click Y
+3. Wait for 3 seconds, and note the appearance of an unexpected message
+
+
+### Details
+
+Provide some additional information:
+
+- PonySFM Workshop version:
+- Operating System + version:


### PR DESCRIPTION
This Issue Template will be used automagically by github web when someone creates a new issue. They will see the template text and hopefully fill in the different sections. This helps reducing the "X is broken. Please fix it" issues, where you then have to ask 10 times to get some details, how to reproduce and so on.